### PR TITLE
Update app name to Spent and change setting default.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!DOCTYPE resources [<!ENTITY app_name "Paycat">]>
+<?xml version="1.0" encoding="utf-8"?><!DOCTYPE resources [<!ENTITY app_name "Spent">]>
 
 <resources>
     <!-- Main application resources. -->

--- a/app/src/main/res/xml/prefs_general.xml
+++ b/app/src/main/res/xml/prefs_general.xml
@@ -1,7 +1,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <SwitchPreference
-        android:defaultValue="false"
+        android:defaultValue="true"
         android:key="match_category"
         android:summary="@string/pref_match_category_summary"
         android:title="@string/pref_match_category_title" />


### PR DESCRIPTION
- Match categories setting now defaults to "true"
- App name changed from Paycat to Spent.