### PR TITLE
Add option to dismiss notification after a transaction is recorded.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "com.ulternate.paycat"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/app/src/main/res/layout/preferences_category.xml
+++ b/app/src/main/res/layout/preferences_category.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2006 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!-- Custom Layout used for PreferenceCategory in a PreferenceActivity. -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+android:id/title"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textColor="@color/colorPrimaryDark"
+    android:textStyle="bold"
+    android:textAllCaps="false"
+    android:layout_marginBottom="16dip"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:paddingTop="16dip"
+    />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,10 +74,20 @@
     <string name="menu_date_filter">Filter Transactions</string>
     <string name="menu_date_filter_edit">Edit Filter</string>
     <string name="menu_clear_date_filter">Remove Filter</string>
-    <!-- Matching Transaction settings. -->
-    <string name="pref_category_match_transactions">Transaction Matching</string>
-    <string name="pref_match_category_title">Match transaction categories</string>
-    <string name="pref_match_category_summary">Try and match transaction categories automatically?</string>
+    <!-- Transaction settings. -->
     <string name="date_from">From</string>
     <string name="date_to">To</string>
+    <string name="pref_category_match_transactions">Transaction Matching</string>
+
+    <!-- Settings keys. -->
+    <string name="pref_match_category_key">match_category</string>
+    <string name="pref_dismiss_notification_key">dismiss_notification</string>
+
+    <!-- Settings titles. -->
+    <string name="pref_match_category_title">Match transaction categories</string>
+    <string name="pref_dismiss_notification_title">Dismiss notification after capture</string>
+
+    <!-- Settings summaries. -->
+    <string name="pref_match_category_summary">Try and match transaction categories automatically?</string>
+    <string name="pref_dismiss_notification_summary">Note, the notification will likely be dismissed before you can see it, making it difficult to confirm the transaction details were captured correctly.</string>
 </resources>

--- a/app/src/main/res/xml/prefs_general.xml
+++ b/app/src/main/res/xml/prefs_general.xml
@@ -1,8 +1,18 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <SwitchPreference
-        android:defaultValue="true"
-        android:key="match_category"
-        android:summary="@string/pref_match_category_summary"
-        android:title="@string/pref_match_category_title" />
+    <PreferenceCategory
+        android:layout="@layout/preferences_category"
+        android:title="@string/pref_category_match_transactions">
+
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/pref_match_category_key"
+            android:summary="@string/pref_match_category_summary"
+            android:title="@string/pref_match_category_title" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/pref_dismiss_notification_key"
+            android:summary="@string/pref_dismiss_notification_summary"
+            android:title="@string/pref_dismiss_notification_title" />
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
- Add preference.
- Check preference when recording Transaction in the NotificationListenerService.
- If the preference is enabled, then dismiss the notification afterwards.

Includes upgrade of minSDKVersion to 21 (Lollipop).